### PR TITLE
Support Caps Lock and Spacebar key labels

### DIFF
--- a/src/components/common/Keyboard/index.jsx
+++ b/src/components/common/Keyboard/index.jsx
@@ -1,4 +1,5 @@
 import styles from './keyboard.module.scss'
+import { getKeyLabel } from 'utils/keyboard'
 
 const Keyboard = ({
 	keyboardLayout = [
@@ -15,7 +16,7 @@ const Keyboard = ({
 				<div className={styles.row} key={i}>
 					{row.map((el, j) => (
 						<div className={styles.key} key={j}>
-							{el}
+							{getKeyLabel(el)}
 						</div>
 					))}
 				</div>

--- a/src/components/common/Keyboard/keyboard.module.scss
+++ b/src/components/common/Keyboard/keyboard.module.scss
@@ -31,7 +31,6 @@
 	border-radius: var(--border-radius);
 	box-shadow: 0rem 0.375rem 0rem rgba(0, 0, 0, 0.25);
 	font-family: var(--key-font);
-	text-transform: uppercase;
 	transition: transform 0.3s, box-shadow 0.3s;
 	transition-delay: 0.3s;
 	user-select: none;

--- a/src/components/game/Keys/index.jsx
+++ b/src/components/game/Keys/index.jsx
@@ -4,6 +4,7 @@
 
 import useStore from "store";
 import { useGameState } from "hooks";
+import { getKeyLabel } from "utils/keyboard";
 import styles from "./keys.module.scss";
 
 const Keys = () => {
@@ -27,7 +28,7 @@ const Keys = () => {
                       ${keyPressed && parseInt(gameState[0]) === i + 1 ? styles.down : null}`}
           key={i + score.toFixed()}
         >
-          {key}
+          {getKeyLabel(key)}
         </div>
       ))}
     </div>

--- a/src/components/game/Keys/keys.module.scss
+++ b/src/components/game/Keys/keys.module.scss
@@ -21,7 +21,6 @@
 	font-family: var(--key-font);
 	font-size: 1.125rem;
 	font-weight: 500;
-	text-transform: uppercase;
 	transition: transform 0.1s, box-shadow 0.1s;
 	user-select: none;
 

--- a/src/components/gameEnd/Table/index.jsx
+++ b/src/components/gameEnd/Table/index.jsx
@@ -1,4 +1,5 @@
 import { roundToTwoDecimals } from "utils/math";
+import { getKeyLabel } from "utils/keyboard";
 import styles from "./table.module.scss";
 
 const Table = ({ children }) => {
@@ -25,8 +26,8 @@ const TableItem = ({ value, label, unit = null, stretch = false, disabled = fals
           <>
             <img src={showBuilding.icon} alt={`${showBuilding.name} icon`} />
             <div className={styles.keys}>
-              <span>{showBuilding.shortcuts[0]}</span>
-              <span>{showBuilding.shortcuts[1]}</span>
+              <span>{getKeyLabel(showBuilding.shortcuts[0])}</span>
+              <span>{getKeyLabel(showBuilding.shortcuts[1])}</span>
             </div>
           </>
         )}

--- a/src/components/gameEnd/Table/table.module.scss
+++ b/src/components/gameEnd/Table/table.module.scss
@@ -92,6 +92,7 @@
 			border-radius: var(--border-radius-sm);
 			font-size: 0.75rem;
 			font-weight: 400;
+			text-transform: none;
 			&:first-child {
 				margin-right: 0.25rem;
 			}

--- a/src/hooks/useKeyPress.js
+++ b/src/hooks/useKeyPress.js
@@ -2,15 +2,21 @@
  * @file Hook to handle keydown events
  */
 import { useState, useEffect } from 'react'
+import { normalizeKey } from 'utils/keyboard'
+
+const ALLOWED_NAMED_KEYS = ['CapsLock', 'Escape']
 
 const useKeyPress = (callback) => {
 	const [keyPressed, setKeyPressed] = useState()
 
 	useEffect(() => {
 		const handleKeyDown = ({ key }) => {
-			if (keyPressed !== key && key.length === 1) {
-				setKeyPressed(key)
-				callback && callback(key.toLowerCase())
+			const normalizedKey = normalizeKey(key)
+			const isAllowedKey = key.length === 1 || ALLOWED_NAMED_KEYS.includes(key)
+
+			if (keyPressed !== normalizedKey && isAllowedKey) {
+				setKeyPressed(normalizedKey)
+				callback && callback(normalizedKey)
 			}
 		}
 		const handleKeyUp = () => {
@@ -23,7 +29,7 @@ const useKeyPress = (callback) => {
 			window.removeEventListener('keyup', handleKeyUp)
 		}
 	})
-	return keyPressed?.toLowerCase()
+	return keyPressed
 }
 
 export default useKeyPress

--- a/src/utils/keyboard.js
+++ b/src/utils/keyboard.js
@@ -9,4 +9,18 @@ const deriveKeyboardLayout = (defaultLayouts, customLayout) => {
 	)
 }
 
-export { deriveKeyboardLayout }
+const normalizeKey = (key) => {
+	if (!key) return key
+
+	return key.length === 1 ? key.toLowerCase() : key
+}
+
+const getKeyLabel = (key) => {
+	if (key === ' ') return 'Spacebar'
+	if (key === 'CapsLock') return 'Caps Lock'
+	if (key?.length === 1) return key.toUpperCase()
+
+	return key
+}
+
+export { deriveKeyboardLayout, getKeyLabel, normalizeKey }

--- a/src/views/modal/Options/KeyboardOptions.jsx
+++ b/src/views/modal/Options/KeyboardOptions.jsx
@@ -2,7 +2,7 @@ import useStore from "store";
 import { useState, useRef, useCallback } from "react";
 import { useOnClickOutside, useKeyPress, useEffectOnce } from "hooks";
 import { WrapSegmentedInputComponent } from "./shared";
-import { deriveKeyboardLayout } from "utils/keyboard";
+import { deriveKeyboardLayout, getKeyLabel } from "utils/keyboard";
 import styles from "./keyboardOptions.module.scss";
 
 // Assets
@@ -132,7 +132,7 @@ const KeyboardOptions = () => {
 										`}
                       key={el === "?" ? col : el}
                     >
-                      <span>{keyCanBeRemapped ? "Press Key" : el}</span>
+                      <span>{keyCanBeRemapped ? "Press Key" : getKeyLabel(el)}</span>
                       {building && showKeyboardIconOverlay && (
                         <div
                           className={`

--- a/src/views/modal/Options/keyboardOptions.module.scss
+++ b/src/views/modal/Options/keyboardOptions.module.scss
@@ -61,7 +61,6 @@
 		padding: 0.25rem 1rem;
 		background: rgba(0, 0, 0, 0.2);
 		border-radius: 0.5rem;
-		text-transform: uppercase;
 		transform: translate3d(-50%, -50%, 0);
 		transition: background-color 0.2s, font-size 0.2s;
 		white-space: nowrap;


### PR DESCRIPTION
## Summary
- allow Caps Lock to be captured as a remappable key
- display the space key as Spacebar across game prompts, keyboard previews, remapping, and results
- keep raw key values unchanged while centralizing keyboard input normalization and labels

## Test
- npm run build

Build completed with existing CRA/postcss-svgo and Browserslist warnings.