### PR TITLE
Support Caps Lock and Spacebar remapping

### DIFF
--- a/src/components/common/Checkbox/index.module.scss
+++ b/src/components/common/Checkbox/index.module.scss
@@ -13,25 +13,38 @@
 	user-select: none;
 
 	& input[type='checkbox'] {
+		position: relative;
 		width: 0.75rem;
 		height: 0.75rem;
 		margin-right: 0.5rem;
 		appearance: none;
-		background-image: url("data:image/svg+xml,%3Csvg width='100%' height='100%' viewBox='0 0 8 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='4' cy='4' r='2' fill='rgba(255,255,255,0.1)'/%3E%3C/svg%3E%0A");
-		background-position: center;
-		background-repeat: no-repeat;
+		border-radius: 50%;
+
+		&::before {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			width: 0.25rem;
+			height: 0.25rem;
+			background: rgba(255, 255, 255, 0.1);
+			border-radius: 50%;
+			content: '';
+			transform: translate(-50%, -50%);
+		}
 	}
 
 	&.checked {
 		background: var(--color-foreground);
 		color: var(--color-font-primary);
 		& input[type='checkbox'] {
-			width: 0.75rem;
-			height: 0.75rem;
-			margin-right: 0.5rem;
-			background-image: url("data:image/svg+xml,%3Csvg width='100%' height='100%' viewBox='0 0 33 27' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2.5 13.5L11 22L30.5 2.5' stroke='rgba(250,225,175,1)' stroke-width='6'/%3E%3C/svg%3E%0A");
-			background-position: center;
-			background-repeat: no-repeat;
+			border: solid rgba(250, 225, 175, 1);
+			border-width: 0 0.1875rem 0.1875rem 0;
+			border-radius: 0;
+			transform: rotate(45deg) translate(-0.0625rem, -0.125rem);
+
+			&::before {
+				display: none;
+			}
 		}
 	}
 

--- a/src/components/common/Keyboard/index.jsx
+++ b/src/components/common/Keyboard/index.jsx
@@ -1,4 +1,5 @@
 import styles from './keyboard.module.scss'
+import { getKeyLabel, hasLongKeyLabel } from 'utils/keyboard'
 
 const Keyboard = ({
 	keyboardLayout = [
@@ -14,8 +15,10 @@ const Keyboard = ({
 			{keyboardLayout.map((row, i) => (
 				<div className={styles.row} key={i}>
 					{row.map((el, j) => (
-						<div className={styles.key} key={j}>
-							{el}
+						<div
+							className={`${styles.key} ${hasLongKeyLabel(el) ? styles.longLabel : null}`}
+							key={j}>
+							{getKeyLabel(el)}
 						</div>
 					))}
 				</div>

--- a/src/components/common/Keyboard/keyboard.module.scss
+++ b/src/components/common/Keyboard/keyboard.module.scss
@@ -20,6 +20,8 @@
 	height: 2rem;
 	align-items: flex-start;
 	justify-content: flex-start;
+	box-sizing: border-box;
+	overflow: hidden;
 	padding: 0.5rem;
 	border: 1px solid rgba(255, 255, 255, 0.1);
 	background: linear-gradient(
@@ -31,7 +33,9 @@
 	border-radius: var(--border-radius);
 	box-shadow: 0rem 0.375rem 0rem rgba(0, 0, 0, 0.25);
 	font-family: var(--key-font);
-	text-transform: uppercase;
+	font-size: 1rem;
+	line-height: 1;
+	white-space: nowrap;
 	transition: transform 0.3s, box-shadow 0.3s;
 	transition-delay: 0.3s;
 	user-select: none;
@@ -45,5 +49,13 @@
 		transform: translateY(0.375rem);
 		transition: transform 0.1s, box-shadow 0.3s;
 		transition-delay: 0s;
+	}
+
+	&.longLabel {
+		align-items: center;
+		justify-content: center;
+		padding: 0.125rem;
+		font-size: 0.375rem;
+		text-align: center;
 	}
 }

--- a/src/components/game/Keys/index.jsx
+++ b/src/components/game/Keys/index.jsx
@@ -4,6 +4,7 @@
 
 import useStore from "store";
 import { useGameState } from "hooks";
+import { getKeyLabel, hasLongKeyLabel } from "utils/keyboard";
 import styles from "./keys.module.scss";
 
 const Keys = () => {
@@ -23,11 +24,12 @@ const Keys = () => {
         <div
           className={`
                       ${styles.key} ${gameState[0] >= i + 1 ? styles.correct : null} 
+                      ${hasLongKeyLabel(key) ? styles.longLabel : null}
                       ${keyLabels}
                       ${keyPressed && parseInt(gameState[0]) === i + 1 ? styles.down : null}`}
           key={i + score.toFixed()}
         >
-          {key}
+          {getKeyLabel(key)}
         </div>
       ))}
     </div>

--- a/src/components/game/Keys/keys.module.scss
+++ b/src/components/game/Keys/keys.module.scss
@@ -8,6 +8,9 @@
 	height: 3.5rem;
 	align-items: center;
 	justify-content: center;
+	box-sizing: border-box;
+	overflow: hidden;
+	padding: 0.25rem;
 	border: 1px solid rgba(255, 255, 255, 0.05);
 	background: linear-gradient(
 			180deg,
@@ -21,9 +24,11 @@
 	font-family: var(--key-font);
 	font-size: 1.125rem;
 	font-weight: 500;
-	text-transform: uppercase;
+	line-height: 1;
+	text-align: center;
 	transition: transform 0.1s, box-shadow 0.1s;
 	user-select: none;
+	white-space: nowrap;
 
 	&:first-child {
 		margin-right: 1rem;
@@ -47,5 +52,9 @@
 
 	&.labeled {
 		color: rgba(255, 255, 255, 1) !important;
+	}
+
+	&.longLabel {
+		font-size: 0.625rem;
 	}
 }

--- a/src/components/gameEnd/Table/index.jsx
+++ b/src/components/gameEnd/Table/index.jsx
@@ -1,4 +1,5 @@
 import { roundToTwoDecimals } from "utils/math";
+import { getKeyLabel, hasLongKeyLabel } from "utils/keyboard";
 import styles from "./table.module.scss";
 
 const Table = ({ children }) => {
@@ -25,8 +26,11 @@ const TableItem = ({ value, label, unit = null, stretch = false, disabled = fals
           <>
             <img src={showBuilding.icon} alt={`${showBuilding.name} icon`} />
             <div className={styles.keys}>
-              <span>{showBuilding.shortcuts[0]}</span>
-              <span>{showBuilding.shortcuts[1]}</span>
+              {showBuilding.shortcuts.map((key, i) => (
+                <span className={hasLongKeyLabel(key) ? styles.longLabel : null} key={i}>
+                  {getKeyLabel(key)}
+                </span>
+              ))}
             </div>
           </>
         )}

--- a/src/components/gameEnd/Table/table.module.scss
+++ b/src/components/gameEnd/Table/table.module.scss
@@ -86,14 +86,29 @@
 	}
 
 	& .keys {
+		display: flex;
+		gap: 0.25rem;
+		justify-content: center;
+		max-width: 5rem;
 		& span {
+			box-sizing: border-box;
+			max-width: 2rem;
+			overflow: hidden;
 			padding: 0.25rem 0.5rem;
 			background: var(--color-foreground);
 			border-radius: var(--border-radius-sm);
 			font-size: 0.75rem;
 			font-weight: 400;
-			&:first-child {
-				margin-right: 0.25rem;
+			line-height: 1;
+			text-align: center;
+			text-transform: none;
+			white-space: nowrap;
+
+			&.longLabel {
+				max-width: 2.25rem;
+				padding-right: 0.25rem;
+				padding-left: 0.25rem;
+				font-size: 0.375rem;
 			}
 		}
 	}

--- a/src/hooks/useKeyPress.js
+++ b/src/hooks/useKeyPress.js
@@ -1,19 +1,32 @@
 /**
  * @file Hook to handle keydown events
  */
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { normalizeKey } from 'utils/keyboard'
+
+const ALLOWED_NAMED_KEYS = ['CapsLock', 'Escape']
 
 const useKeyPress = (callback) => {
 	const [keyPressed, setKeyPressed] = useState()
+	const callbackRef = useRef(callback)
+	const keyPressedRef = useRef()
+
+	callbackRef.current = callback
 
 	useEffect(() => {
-		const handleKeyDown = ({ key }) => {
-			if (keyPressed !== key && key.length === 1) {
-				setKeyPressed(key)
-				callback && callback(key.toLowerCase())
+		const handleKeyDown = (event) => {
+			const { key } = event
+			const normalizedKey = normalizeKey(key)
+			const isAllowedKey = key.length === 1 || ALLOWED_NAMED_KEYS.includes(key)
+
+			if (keyPressedRef.current !== normalizedKey && isAllowedKey) {
+				keyPressedRef.current = normalizedKey
+				setKeyPressed(normalizedKey)
+				callbackRef.current && callbackRef.current(normalizedKey, event)
 			}
 		}
 		const handleKeyUp = () => {
+			keyPressedRef.current = null
 			setKeyPressed(null)
 		}
 		window.addEventListener('keydown', handleKeyDown)
@@ -22,8 +35,8 @@ const useKeyPress = (callback) => {
 			window.removeEventListener('keydown', handleKeyDown)
 			window.removeEventListener('keyup', handleKeyUp)
 		}
-	})
-	return keyPressed?.toLowerCase()
+	}, [])
+	return keyPressed
 }
 
 export default useKeyPress

--- a/src/utils/keyboard.js
+++ b/src/utils/keyboard.js
@@ -9,4 +9,20 @@ const deriveKeyboardLayout = (defaultLayouts, customLayout) => {
 	)
 }
 
-export { deriveKeyboardLayout }
+const normalizeKey = (key) => {
+	if (!key) return key
+
+	return key.length === 1 ? key.toLowerCase() : key
+}
+
+const getKeyLabel = (key) => {
+	if (key === ' ') return 'Spacebar'
+	if (key === 'CapsLock') return 'Caps Lock'
+	if (key?.length === 1) return key.toUpperCase()
+
+	return key
+}
+
+const hasLongKeyLabel = (key) => getKeyLabel(key)?.length > 1
+
+export { deriveKeyboardLayout, getKeyLabel, hasLongKeyLabel, normalizeKey }

--- a/src/views/modal/Options/KeyboardOptions.jsx
+++ b/src/views/modal/Options/KeyboardOptions.jsx
@@ -2,7 +2,7 @@ import useStore from "store";
 import { useState, useRef, useCallback } from "react";
 import { useOnClickOutside, useKeyPress, useEffectOnce } from "hooks";
 import { WrapSegmentedInputComponent } from "./shared";
-import { deriveKeyboardLayout } from "utils/keyboard";
+import { deriveKeyboardLayout, getKeyLabel, hasLongKeyLabel } from "utils/keyboard";
 import styles from "./keyboardOptions.module.scss";
 
 // Assets
@@ -33,8 +33,9 @@ const KeyboardOptions = () => {
   // Cancel key rebind when clicked outside of keymap area
   useOnClickOutside(gridRef, () => setKeyCanBeMapped(""));
 
-  useKeyPress((key) => {
+  useKeyPress((key, event) => {
     if (!keyCanBeMapped) return;
+    event?.preventDefault();
     if (key === "Escape") return setKeyCanBeMapped("");
 
     const row = keyCanBeMapped[0];
@@ -124,15 +125,15 @@ const KeyboardOptions = () => {
                         "--flash": keyHighlightOnChange,
                       }}
                       className={`
-												${styles.key} 
-                                                ${styles.highlight} 
-												${keyCanBeRemapped ? styles.rebind : null}
-												${el === "?" ? styles.missing : null}	
-
-										`}
+                        ${styles.key}
+                        ${styles.highlight}
+                        ${hasLongKeyLabel(el) ? styles.longLabel : null}
+                        ${keyCanBeRemapped ? styles.rebind : null}
+                        ${el === "?" ? styles.missing : null}
+                      `}
                       key={el === "?" ? col : el}
                     >
-                      <span>{keyCanBeRemapped ? "Press Key" : el}</span>
+                      <span>{keyCanBeRemapped ? "Press Key" : getKeyLabel(el)}</span>
                       {building && showKeyboardIconOverlay && (
                         <div
                           className={`

--- a/src/views/modal/Options/keyboardOptions.module.scss
+++ b/src/views/modal/Options/keyboardOptions.module.scss
@@ -58,13 +58,21 @@
 		position: absolute;
 		top: 50%;
 		left: 50%;
+		box-sizing: border-box;
+		max-width: calc(100% - 0.75rem);
+		overflow: hidden;
 		padding: 0.25rem 1rem;
 		background: rgba(0, 0, 0, 0.2);
 		border-radius: 0.5rem;
-		text-transform: uppercase;
 		transform: translate3d(-50%, -50%, 0);
 		transition: background-color 0.2s, font-size 0.2s;
 		white-space: nowrap;
+	}
+
+	&.longLabel span {
+		padding: 0.25rem 0.5rem;
+		font-size: 0.625rem;
+		text-align: center;
 	}
 
 	&.missing span {


### PR DESCRIPTION
## Summary
- allow Caps Lock and Space to be captured as remappable keys
- display Space as Spacebar and CapsLock as Caps Lock across key prompts and key previews
- keep longer key labels inside keycap boxes
- fix the remap flow so Space/Caps Lock register with one keypress
- replace checkbox SVG data URIs with CSS shapes so production CI builds do not fail on CSS optimizer warnings

## Test
- CI=true npm run build
- Browser-tested local remapping: one press changes Q to Spacebar and W to Caps Lock, with labels fitting in the options key boxes.

Note: this PR intentionally excludes README.md and .gitignore changes.